### PR TITLE
bugfix: np.int deprecated

### DIFF
--- a/modules/alignment.py
+++ b/modules/alignment.py
@@ -21,9 +21,9 @@ def pileup(paf, genome_size):
         Ins: genome each base [0-2]: 1st Ins, 2nd Ins, 3rd Ins; [0-3]: ATCG
     """
     ins_len = 7
-    arr = np.zeros((genome_size, 5), dtype=np.int)
-    coverage = np.zeros(genome_size, dtype=np.int)
-    ins = np.zeros((genome_size, ins_len, 4), dtype=np.int)
+    arr = np.zeros((genome_size, 5), dtype=np.int64)
+    coverage = np.zeros(genome_size, dtype=np.int64)
+    ins = np.zeros((genome_size, ins_len, 4), dtype=np.int64)
     
     over_ins = []  
     with open(paf, 'r') as f:        

--- a/modules/mod_polish.py
+++ b/modules/mod_polish.py
@@ -485,9 +485,9 @@ def MismatchPileup(file_name, genome_size):
     LONG_DELETION_LENGTH = 50
     misAry = np.array([np.array([0,np.zeros(8)])for i in range(genome_size)])
     ins_len = 7
-    arr = np.zeros((genome_size, 9), dtype=np.int)
-    coverage = np.zeros(genome_size, dtype=np.int)
-    ins = np.zeros((genome_size, ins_len, 4), dtype=np.int)
+    arr = np.zeros((genome_size, 9), dtype=np.int64)
+    coverage = np.zeros(genome_size, dtype=np.int64)
+    ins = np.zeros((genome_size, ins_len, 4), dtype=np.int64)
     over_ins = [] 
     with open(file_name, 'r') as f:        
         for line in f:
@@ -598,9 +598,9 @@ def MismatchPileup_read_bam(bam,genome_size):
     LONG_DELETION_LENGTH = 50
     misAry = np.array([np.array([0,np.zeros(8)])for i in range(genome_size)])
     ins_len = 7
-    arr = np.zeros((genome_size, 9,3), dtype=np.int)
-    coverage = np.zeros(genome_size, dtype=np.int)
-    ins = np.zeros((genome_size, ins_len, 4), dtype=np.int)
+    arr = np.zeros((genome_size, 9,3), dtype=np.int64)
+    coverage = np.zeros(genome_size, dtype=np.int64)
+    ins = np.zeros((genome_size, ins_len, 4), dtype=np.int64)
     over_ins = []
     totalCovergae = 0
     bamData = pysam.AlignmentFile(bam,'rb')


### PR DESCRIPTION
`np.int` has been deprecated since numpy 1.20. [^1]

For future proofing the code, this PR replaced `np.int` with `np.int64`.

With this modification, the program now at least imports in python 3.13 with the following dependencies, though I haven't test it on real data to check if the result remains the same.

```
Package            Version
------------------ -----------
biopython          1.85
certifi            2025.1.31
charset-normalizer 3.4.1
feather-format     0.4.1
idna               3.10
joblib             1.4.2
more-itertools     10.6.0
numpy              2.2.4
pandas             2.2.3
pip                24.3.1
pyarrow            19.0.1
pycurl             7.45.6
pysam              0.23.0
python-dateutil    2.9.0.post0
pytz               2025.2
requests           2.32.3
scikit-learn       1.6.1
scipy              1.15.2
six                1.17.0
threadpoolctl      3.6.0
tzdata             2025.2
urllib3            2.3.0
wget               3.2
```

[^1]: https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated